### PR TITLE
Switch to using inspect4py output folder

### DIFF
--- a/backend/default_config.yaml
+++ b/backend/default_config.yaml
@@ -1,5 +1,5 @@
 uri: neo4j://localhost:7687
 username: neo4j
 password: s3cr3t
-input: ../test/directory_info.json
+input: ../test
 prune: True

--- a/backend/repograph/cli.py
+++ b/backend/repograph/cli.py
@@ -2,14 +2,16 @@
 Command-Line Interface for manual invocation.
 """
 import configargparse
-
+import os
 
 from repograph.utils.logging import configure_logging
 from repograph.builder.repograph_builder import RepographBuilder
 from repograph.utils.json import read_json_from_file
 
+# Configure logging format
 configure_logging()
 
+# Command-line / config-file argument parsing
 p = configargparse.ArgParser()
 p.add_argument('-c', '--config', is_config_file=True, help='Config file path.')
 p.add_argument('--uri', required=True, help='The URI of the Neo4J server.')
@@ -31,6 +33,11 @@ p.add_argument(
 )
 
 
+def parse_inspect4py_output(path):
+    return read_json_from_file(os.path.join(path, "directory_info.json")), \
+        read_json_from_file(os.path.join(path, "call_graph.json"))
+
+
 if __name__ == "__main__":
     args, _ = p.parse_known_args()
     builder = RepographBuilder(
@@ -41,5 +48,6 @@ if __name__ == "__main__":
         args.prune,
         args.summarize
     )
-    directory_info = read_json_from_file(args.input)
+
+    directory_info, call_graph = parse_inspect4py_output(args.input)
     repograph = builder.build(directory_info)  # noqa


### PR DESCRIPTION
So that we can leverage the call_graph as well. Closes #70.