### PR TITLE
Fix Dependabot security vulnerabilities (Python + npm)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -64,12 +64,13 @@ jedi==0.18.2
 Jinja2==3.1.2
 joblib==1.2.0
 json2html==1.3.0
-jsonschema==4.17.3
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
 jupyter==1.0.0
 jupyter_client==8.0.3
 jupyter-console==6.6.3
 jupyter_core==5.2.0
-jupyter-events==0.6.3
+jupyter-events==0.12.1
 jupyter_server==2.18.0
 jupyter_server_terminals==0.4.4
 jupyterlab-pygments==0.2.2
@@ -98,7 +99,8 @@ nltk==3.9.4
 notebook==6.5.3
 notebook_shim==0.2.2
 numpy==1.24.1
-packaging==21.3
+overrides==7.7.0
+packaging==26.2
 pandas==1.5.3
 pandocfilters==1.5.0
 pansi==2020.7.3
@@ -127,6 +129,8 @@ pyflakes==3.0.1
 Pygments==2.14.0
 pyparsing==3.0.9
 pyrsistent==0.19.3
+referencing==0.37.0
+rpds-py==0.30.0
 python-dateutil==2.8.2
 python-json-logger==2.0.7
 python-multipart==0.0.27
@@ -143,7 +147,7 @@ rich==13.3.1
 scikit-learn==1.2.1
 scipy==1.10.0
 seaborn==0.12.2
-Send2Trash==1.8.0
+Send2Trash==2.1.0
 sentence-transformers==2.2.2
 sentencepiece==0.1.97
 setuptools==54.2.0
@@ -175,7 +179,7 @@ urllib3==1.26.14
 uvicorn==0.20.0
 wcwidth==0.2.6
 webencodings==0.5.1
-websocket-client==1.5.1
+websocket-client==1.9.0
 wheel==0.38.4
 widgetsnbextension==4.0.5
 yarl==1.17.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -110,7 +110,7 @@ pathspec==0.11.0
 pep517==0.13.0
 pexpect==4.8.0
 pickleshare==0.7.5
-pigar==2.0.5
+pigar==2.2.0
 Pillow==12.2.0
 pip==26.1
 pkgutil_resolve_name==1.3.10

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -47,7 +47,7 @@ flit_core==3.8.0
 fonttools==4.39.0
 frozenlist==1.3.3
 gitdb==4.0.10
-GitPython==3.1.30
+GitPython==3.1.49
 graphviz==0.20.1
 h11==0.14.0
 huggingface-hub==0.12.0
@@ -70,7 +70,7 @@ jupyter_client==8.0.3
 jupyter-console==6.6.3
 jupyter_core==5.2.0
 jupyter-events==0.6.3
-jupyter_server==2.4.0
+jupyter_server==2.18.0
 jupyter_server_terminals==0.4.4
 jupyterlab-pygments==0.2.2
 jupyterlab-widgets==3.0.5
@@ -88,7 +88,7 @@ multidict==6.0.4
 mypy-extensions==1.0.0
 nbclassic==0.5.3
 nbclient==0.7.2
-nbconvert==7.2.9
+nbconvert==7.17.1
 nbformat==5.7.3
 neo4j==5.5.0
 neo4j-driver==5.5.0
@@ -110,7 +110,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pigar==2.0.5
 Pillow==12.2.0
-pip==23.0
+pip==26.1
 pkgutil_resolve_name==1.3.10
 platformdirs==2.5.2
 prometheus-client==0.16.0
@@ -129,7 +129,7 @@ pyparsing==3.0.9
 pyrsistent==0.19.3
 python-dateutil==2.8.2
 python-json-logger==2.0.7
-python-multipart==0.0.26
+python-multipart==0.0.27
 pytz==2022.7.1
 PyYAML==6.0
 pyzmq==25.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,7 +14,7 @@ backports.functools-lru-cache==1.6.4
 beautifulsoup4==4.11.2
 bigcode-astgen==0.2.1
 black==22.12.0
-bleach==6.0.0
+bleach==6.3.0
 CacheControl==0.12.11
 certifi==2022.12.7
 cffi==1.15.1
@@ -164,7 +164,7 @@ tabulate==0.9.0
 tenacity==8.1.0
 terminado==0.17.1
 threadpoolctl==3.1.0
-tinycss2==1.2.1
+tinycss2==1.4.0
 tokenizers==0.13.2
 tomli==2.0.1
 torch==1.13.1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,7 +38,7 @@
         "autoprefixer": "^10.4.12",
         "babel-loader": "^9.1.0",
         "babel-plugin-macros": "^3.1.0",
-        "postcss": "^8.4.21",
+        "postcss": "^8.5.10",
         "prettier": "^2.8.3",
         "prettier-plugin-tailwindcss": "^0.2.1",
         "tailwindcss": "^3.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "autoprefixer": "^10.4.12",
     "babel-loader": "^9.1.0",
     "babel-plugin-macros": "^3.1.0",
-    "postcss": "^8.4.21",
+    "postcss": "^8.5.10",
     "prettier": "^2.8.3",
     "prettier-plugin-tailwindcss": "^0.2.1",
     "tailwindcss": "^3.2.4",


### PR DESCRIPTION
## Summary

Remediates 6 open Dependabot alerts across the Python backend and Next.js frontend.

| Package | Before | After | Alerts closed |
|---|---|---|---|
| `GitPython` | 3.1.30 | 3.1.49 | #230 #231 #237 #238 (HIGH) |
| `jupyter_server` | 2.4.0 | 2.18.0 | #233 #234 #235 (HIGH) #232 (MEDIUM) |
| `python-multipart` | 0.0.26 | 0.0.27 | #239 (HIGH) |
| `nbconvert` | 7.2.9 | 7.17.1 | #226 #227 (MEDIUM) |
| `pip` | 23.0 | 26.1 | #236 (MEDIUM) |
| `postcss` | ^8.4.21 | ^8.5.10 | #229 (MEDIUM) |

## Remaining open alerts

- **#221 `transformers`** — fix requires a 4.x → 5.x major version bump. The app uses `RobertaTokenizer` and `T5ForConditionalGeneration` directly, so API compatibility needs verifying before bumping. Tracked separately.
- **#228 `pip`** — interpretation conflict CVE with no upstream patch available yet.

## Test plan

- [x] Backend unit tests pass (55/64 — the 9 failures are pre-existing: demo repos not cloned + NLTK data not downloaded, unrelated to these changes)
- [ ] Run `npm install` in `frontend/` to update `package-lock.json` with the new `postcss` version
- [ ] Smoke test backend after updating the `repograph` conda env with new requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)